### PR TITLE
Restrict Peer Dependencies to Non-Breaking Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
   "typings": "./dist/src/index.d.ts",
   "version": "1.2.0",
   "peerDependencies": {
-    "slonik": "*"
+    "slonik": "<27"
   }
 }


### PR DESCRIPTION
Hello gajus,

I recently discovered an issue with this community package when testing out version 27.  I discovered that Slonik 27 introduces breaking changes on TypeScript exported type names.  See https://github.com/gajus/slonik/releases/tag/v27.0.0.  The version of this library currently depends on the names from version 26.
The current peerDepedenecies semver includes version 27.  This should be restricted to avoid these breaking changes as TypeScript will fail to compile.

Hope this helps, I can submit an example to reproduce the issue if needed.
Cheers,
Matt